### PR TITLE
feature：闪回自动检测

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 .pyre/
 
 \[AutoSave\].txt
+urls.json

--- a/src/Editor.py
+++ b/src/Editor.py
@@ -454,9 +454,10 @@ class Editor():
         text = text.replace(',', '，')
         text = text.replace('?', '？')
         text = text.replace('!', '！')
+        text = text.replace('~', '～')
         text = text.replace('欸', '诶')
 
-        normalend = ['、', '，', '。', '？', '！', '~', '～', '♪', '☆', '.', '—']
+        normalend = ['、', '，', '。', '？', '！', '～', '♪', '☆', '.', '—']
         unusualend = ['）', '」', '』', '”']
         if text[-1] in normalend:
             if '.，' in text or '.。' in text:

--- a/src/Editor.py
+++ b/src/Editor.py
@@ -2,6 +2,7 @@ from PyQt5.QtWidgets import QWidget, QTableWidget, QTableWidgetItem, QPushButton
 from PyQt5.QtGui import QBrush, QColor
 from PyQt5.QtCore import Qt, QSize
 import copy
+import math
 
 from Dictionary import characterDict
 
@@ -417,6 +418,16 @@ class Editor():
 
         self.updateHiddenRowMap()
 
+    # Half-width for ascii characters
+    def lineLength(self, s):
+        count = 0
+        for char in s:
+            if ord(char) <= 127:
+                count += 0.5
+            else:
+                count += 1
+        return math.ceil(count)
+
     def checkText(self, speaker, text):
         check = True
         if (speaker not in ["", u"场景", u"左上场景", u"选项"]) and (not text):
@@ -445,7 +456,7 @@ class Editor():
         text = text.replace('!', '！')
         text = text.replace('欸', '诶')
 
-        normalend = ['、', '，', '。', '？', '！', '~', '♪', '☆', '.', '—']
+        normalend = ['、', '，', '。', '？', '！', '~', '～', '♪', '☆', '.', '—']
         unusualend = ['）', '」', '』', '”']
         if text[-1] in normalend:
             if '.，' in text or '.。' in text:
@@ -464,7 +475,8 @@ class Editor():
                 text += "\n【破折号用双破折——，或者视情况删掉】"
                 check = False
 
-        if len(text.split("\n")[0].replace('...', '…')) >= 30:
+        # if len(text.split("\n")[0].replace('...', '…')) >= 30:
+        if self.lineLength(text.split("\n")[0].replace('...', '…')) >= 30:
             text += "\n【单行过长，请删减或换行】"
             check = False
 

--- a/src/Flashback.py
+++ b/src/Flashback.py
@@ -72,11 +72,15 @@ class FlashbackAnalyzer:
         words = Words(clue.split('_'))
         first_indicator = words.pick(0)
 
+        # Skip 'sc' for 'sc_ev_xxxx'
+        if first_indicator == 'sc':
+            first_indicator = words.pick(0)
+
         hints = []
 
         if first_indicator == 'ev':
 
-            hints.append("活动剧情 - 格式通常为ev_[团队名]_[第X次]_话数。\n- X以活动种类（混合 or 各团团队活动等）分别计数。\n- X可能为空。")
+            hints.append("\n活动剧情 - 格式通常为ev_[活动种类]_[第X次]_话数。\n- X以活动种类（混合(shuffle) or 各团团队活动等）分别计数。\n- X可能为空（如第53期活动的X就为空）。")
             
             try:
                 ep = int(words.pick(-1))
@@ -93,16 +97,16 @@ class FlashbackAnalyzer:
             hints.append("主线剧情 - 序章")
         
         elif first_indicator == 'unit':
-            hints.append("推测为主线剧情VSinger部分 - 序号为话数，所有团一起计算话数")
+            hints.append("\n推测为主线剧情VSinger部分\n- 序号为话数，所有团一起计算话数")
         
         elif first_indicator == 'card':
-            hints.append("""卡面剧情 - 格式通常为card_[卡面所属活动/事件]_[角色ID]_[星数和前后篇]。
+            hints.append("""\n卡面剧情\n格式通常为card_[卡面所属活动/事件]_[角色ID]_[星数和前后篇]。
 - 所属活动/事件可能为空，此时推测为初始卡面；ev_开头为活动卡面，见下"关于活动ID"
 - 角色ID: 1-一歌 2-咲希 ... 5-实乃里 ... 9-心羽 ... 21-MIKU 22-RIN ...
 - 星数和前后篇：4a = 4星前篇, 2b = 2星后篇 etc.
-- 活动ID: 格式通常为ev_[团队名]_[第X次]_话数。
-  - X以活动种类（混合 or 各团团队活动等）分别计数。
-  - X可能为空。""")
+- 活动ID: 格式通常为ev_[活动种类]_[第X次]_话数。
+  - X以活动种类（混合(shuffle) or 各团团队活动等）分别计数。
+  - X可能为空（如第53期活动的X就为空）。""")
         
         return hints
 

--- a/src/Flashback.py
+++ b/src/Flashback.py
@@ -96,8 +96,11 @@ class FlashbackAnalyzer:
                 event_desc['chapters'] = [c['title'] for c in event['chapters']]
                 self.events[event['id']] = event_desc
 
-            # Hard-coded event properties
-            self.events[9]['choffset'] = 1
+            try:
+                # Hard-coded event properties
+                self.events[9]['choffset'] = 1
+            except:
+                pass
 
             # Obtain event id clue from areatalks
             for areatalk in self.listManager.areatalks:

--- a/src/Flashback.py
+++ b/src/Flashback.py
@@ -1,0 +1,130 @@
+import re
+
+class Words:
+    def __init__(self, words):
+        self.words = words
+    
+    def pick(self, id):
+        try:
+            w = self.words[id]
+            del self.words[id]
+            return w
+        except IndexError:
+            return ''
+
+    def __getitem__(self, id):
+        return self.words[id]
+
+    def __len__(self):
+        return len(self.words)
+
+class FlashbackAnalyzer:
+
+    def __init__(self):
+
+        # Flashback
+        pattern = r'voice_(.+)_\d+[a-z]?_\d+(?:_?.*)?$'
+        self.flashback_re = re.compile(pattern)
+
+    '''
+    Infer clue (some scenarioID) from voice id
+
+      VoiceId examples:                         Matched Clue:                   Interpretation:
+    - voice_op_band0_15_03                      op_band0                        Leo/Need opening
+    - voice_card_18_3a_27_18                    card_18_3a                      Card: (18)Mafuyu (3)3Star (a)Part1
+    - voice_ms_night13_28_18                    ms_night13                      (ms)Main Story - (night)Niigo - (13)Ep.13
+    - voice_ev_wl_band_01_05_28_03              ev_wl_band_01_05                (ev)Event Story - (wl)World Link - (band)Leo/Need - (01)1st World Link?? - (05)Ep.5
+    - voice_ev_street_18_06_98b_67              ev_street_18_06                 ev - (street)Vivid BAD SQUAD - (18)18th Unit Event (i.e., #135 OVER RAD SQUAD!!) - (06)Ep.6
+                                                                                (98b)Variation? of voice used in line 98 (this one is at line 383) - (67)Character ID = Ken Shiraishi
+    - voice_card_3rdaniv_20_2b_06_20            card_3rdaniv_20_2b              Card: (3rdaniv)Brand New Style - (20)Mizuki - (2)2Star (b)Part2
+    - voice_card_ev_wl_wonder_01_15_4a_20_15    card_ev_wl_wonder_01_15_4a      Card: (ev_wl_wonder_01)WxS 1st WL - (15)Nene - (4)4Star (a)Part1
+    - voice_ev_night__06_20_19                  ev_night__06                    (ev_night)Niigo event - *appearently two underscores* - (06)Ep.6 (Event ID MISSING, this is from #53)
+    - voice_sc_ev_shuffle_10_01_14_03           sc_ev_shuffle_10_01             (sc)?? - (ev)Event - (shuffle)Mixed Event - (10)#10 Mixed (#30 - The BEST Summer Ever!) - (01)Ep.1
+    - areatalk_ev_band_02_004_006
+    - 3rd_anniversary_login_band_05_01
+    - partvoice_28_021_band                     True (Ignored)                  (partvoice)General short voice for VSingers - (28)Voice No.28? - (021)MIKU - (band)Sub-unit: Leo/Need
+
+    returns: clue
+    - None: No idea
+    - True: Should be ignored
+    - str : clue string, usually indicates scenarioID (for flashbacks, this will refer previous scenarioID)
+    '''
+    def getClueFromVoiceID(self, voiceId):
+        
+        #    partvoice - general partial voices (mainly vsinger in card stories etc.)
+        if 'partvoice' in voiceId:
+            return True
+
+        match = self.flashback_re.search(voiceId)
+        if match:
+            scenarioId = match.group(1)
+            clue = scenarioId
+            return clue
+        else:
+            return None # No idea what is this
+
+    # TODO: Automaton / FSM?
+    def getClueHints(self, clue, lang = 'zh-cn'):
+
+        if lang != 'zh-cn':
+            raise NotImplementedError
+
+        words = Words(clue.split('_'))
+        first_indicator = words.pick(0)
+
+        hints = []
+
+        if first_indicator == 'ev':
+
+            hints.append("活动剧情 - 格式通常为ev_[团队名]_[第X次]_话数。\n- X以活动种类（混合 or 各团团队活动等）分别计数。\n- X可能为空。")
+            
+            try:
+                ep = int(words.pick(-1))
+                hints.append("第%02d话" % ep)
+            except ValueError:
+                pass
+
+            # hints += self.getClueHintsFromEvent(words, lang)
+
+        elif first_indicator == 'ms':
+            hints.append("主线剧情")
+        
+        elif first_indicator == 'op':
+            hints.append("主线剧情 - 序章")
+        
+        elif first_indicator == 'unit':
+            hints.append("推测为主线剧情VSinger部分 - 序号为话数，所有团一起计算话数")
+        
+        elif first_indicator == 'card':
+            hints.append("""卡面剧情 - 格式通常为card_[卡面所属活动/事件]_[角色ID]_[星数和前后篇]。
+- 所属活动/事件可能为空，此时推测为初始卡面；ev_开头为活动卡面，见下"关于活动ID"
+- 角色ID: 1-一歌 2-咲希 ... 5-实乃里 ... 9-心羽 ... 21-MIKU 22-RIN ...
+- 星数和前后篇：4a = 4星前篇, 2b = 2星后篇 etc.
+- 活动ID: 格式通常为ev_[团队名]_[第X次]_话数。
+  - X以活动种类（混合 or 各团团队活动等）分别计数。
+  - X可能为空。""")
+        
+        return hints
+
+    # Too hard
+    def getClueHintsFromEvent(self, words, lang = 'zh-cn'):
+
+        if lang != 'zh-cn':
+            raise NotImplementedError
+        
+        hints = []
+
+        w = words.pick(0)
+        if w == 'wl':
+            hints.append("World Link活动")
+            w = words.pick(0)
+        
+        teams = {
+            'band': "Leo/Need 团队活动",
+            'idol': "MORE MORE JUMP! 团队活动",
+            'street': "Vivid BAD SQUAD 团队活动",
+            'wonder': "Wonderlands x Showtime 团队活动",
+            'night': "25时，在nightcord 团队活动",
+            'piapro': "VIRTUAL SINGER 团队活动",
+            'shuffle': "混合活动"
+        }

--- a/src/Flashback.py
+++ b/src/Flashback.py
@@ -286,7 +286,7 @@ class FlashbackAnalyzer:
 
             event_id = str(words)
 
-            event_hints = u"卡面来自：%s" % event_id
+            event_hints = u"卡面来自 %s" % event_id
             if event_id == '':
                 event_hints = u"初期卡面"
             else:
@@ -304,6 +304,9 @@ class FlashbackAnalyzer:
 # - 活动ID: 格式通常为ev_[活动种类]_[第X次]_话数。
 #   - X以活动种类（混合(shuffle) or 各团团队活动等）分别计数。
 #   - X可能为空（如第53期活动的X就为空）。""")
+
+        else:
+            hints.append(u"闪回：未知来源")
         
         return hints
 

--- a/src/Flashback.py
+++ b/src/Flashback.py
@@ -43,8 +43,14 @@ class FlashbackAnalyzer:
 
         self.listManager = listManager
 
+        # "night_15" -> events.json objects (from self.events)
+        # "wl_band_01" -> events.json objects
         self.clue_dict = {}
+        
+        # "band" -> mainStory.json objects
         self.mainstory = {}
+        
+        # eventId: int -> events.json objects (necessary info only)
         self.events = {}
 
         self.noClue = {
@@ -79,7 +85,7 @@ class FlashbackAnalyzer:
                 event_desc = {
                     'id': event['id'],
                     'title': event['title'],
-                    'choffset': 0,
+                    'choffset': 0, # Some event stories start from Ep. "00" instead of "01", e.g., #9
                     'chapters': [],
                 }
                 self.events[event['id']] = event_desc
@@ -111,10 +117,15 @@ class FlashbackAnalyzer:
                         event_clue = "wl_" + event_clue
                     
                     add_to_dict = False
+
                     if event_clue in self.clue_dict:
+
                         prev_id = self.clue_dict[event_clue]['id']
+
+                        # Use the earliest event
                         if prev_id >= 0 and prev_id > areatalk['addEventId']:
                             add_to_dict = True
+
                     else:
                         add_to_dict = True
 

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -145,11 +145,22 @@ class JsonLoader():
         self.table.setCurrentCell(0, 0)
 
     '''
-    Checks if a talkdata contains flashback by voice id
-    VoiceId examples: 
-    - voice_op_band0_15_03
-    - voice_card_18_3a_27_18
-    - voice_ms_night13_28_18
+    Infer clue (some scenarioID) from voice id
+
+      VoiceId examples:                         Matched Clue:                   Interpretation:
+    - voice_op_band0_15_03                      op_band0                        Leo/Need opening
+    - voice_card_18_3a_27_18                    card_18_3a                      Card: (18)Mafuyu (3)3Star (a)Part1
+    - voice_ms_night13_28_18                    ms_night13                      (ms)Main Story - (night)Niigo - (13)Ep.13
+    - voice_ev_wl_band_01_05_28_03              ev_wl_band_01_05                (ev)Event Story - (wl)World Link - (band)Leo/Need - (01)1st World Link?? - (05)Ep.5
+    - voice_ev_street_18_06_98b_67              ev_street_18_06                 ev - (street)VIVID Bad SQUAD - (18)18th Unit Event (i.e., #135 OVER RAD SQUAD!!) - (06)Ep.6
+                                                                                (98b)Variation? of voice used in line 98 (this one is at line 383) - (67)Character ID = Ken Shiraishi
+    - voice_card_3rdaniv_20_2b_06_20            card_3rdaniv_20_2b              Card: (3rdaniv)Brand New Style - (20)Mizuki - (2)2Star (b)Part2
+    - voice_card_ev_wl_wonder_01_15_4a_20_15    card_ev_wl_wonder_01_15_4a      Card: (ev_wl_wonder_01)WxS 1st WL - (15)Nene - (4)4Star (a)Part1
+    - voice_ev_night__06_20_19                  ev_night__06                    (ev_night)Niigo event - *appearently two underscores* - (06)Ep.6 (Event ID MISSING, this is from #53)
+    - voice_sc_ev_shuffle_10_01_14_03           sc_ev_shuffle_10_01             (sc)?? - (ev)Event - (shuffle)Mixed Event - (10)#10 Mixed (#30 - The BEST Summer Ever!) - (01)Ep.1
+    - areatalk_ev_band_02_004_006
+    - 3rd_anniversary_login_band_05_01
+    - partvoice_28_021_band                     True (Ignored)                  (partvoice)General short voice for VSingers - (28)Voice No.28? - (021)MIKU - (band)Sub-unit: Leo/Need
 
     returns: clue
     - None: No idea

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -1,5 +1,5 @@
 from PyQt5.QtWidgets import QTableWidgetItem, QPushButton
-from PyQt5.QtGui import QIcon
+from PyQt5.QtGui import QIcon, QColor
 import PyQt5.QtMultimedia as media
 from PyQt5.QtCore import QUrl
 
@@ -28,6 +28,8 @@ class JsonLoader():
 
         with open(path, 'r', encoding='UTF-8') as f:
             fulldata = json.load(f)
+        
+        scenario_id = fulldata['ScenarioId']
 
         for snippet in fulldata['Snippets']:
             # TalkData
@@ -36,14 +38,24 @@ class JsonLoader():
                 speaker = talkdata['WindowDisplayName'].split("_")[0]
                 text = talkdata['Body']
                 voices = []
+                is_in_event = True
+
                 for voice in talkdata['Voices']:
+
                     # TODO download voice file and play
                     voices.append(voice['VoiceId'])
+
+                    # Check if flashback
+                    if scenario_id not in voice['VoiceId']:
+                        is_in_event = False
+
                 close = talkdata['WhenFinishCloseWindow']
 
                 self.talks.append({
                     'speaker': speaker,
-                    'text': text.rstrip()
+                    'text': text.rstrip(),
+                    'voices': voices,
+                    'flashback': not is_in_event
                 })
 
                 row = self.table.rowCount()
@@ -60,7 +72,13 @@ class JsonLoader():
                     self.table.setItem(row, 0, icon)
                 else:
                     self.table.setItem(row, 0, QTableWidgetItem(speaker))
-                self.table.setItem(row, 1, QTableWidgetItem(text))
+                
+                textItem = QTableWidgetItem(text)
+                if not is_in_event:
+                    textItem.setBackground(QColor(220, 255, 240))
+                    textItem.setToolTip(str(voices))
+                self.table.setItem(row, 1, textItem)
+
                 # buttonPlay = QPushButton("")
                 # buttonPlay.clicked.connect(self.play)
                 # self.table.setCellWidget(row, 2, buttonPlay)
@@ -70,7 +88,7 @@ class JsonLoader():
                 if close:
                     self.talks.append({
                         'speaker': '',
-                        'text': ''
+                        'text': '',
                     })
 
                     row = self.table.rowCount()
@@ -93,7 +111,7 @@ class JsonLoader():
                     
                     self.talks.append({
                         'speaker': speaker,
-                        'text': text
+                        'text': text,
                     })
 
                     row = self.table.rowCount()
@@ -103,7 +121,7 @@ class JsonLoader():
 
                     self.talks.append({
                         'speaker': '',
-                        'text': ''
+                        'text': '',
                     })
 
                     row = self.table.rowCount()

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -34,7 +34,7 @@ class JsonLoader():
 
         self.talks = []
         self.table.setRowCount(0)
-        self.setFontSize(fontSize)        
+        self.setFontSize(fontSize)
 
         with open(path, 'r', encoding='UTF-8') as f:
             fulldata = json.load(f)

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -2,6 +2,7 @@ from PyQt5.QtWidgets import QTableWidgetItem, QPushButton
 from PyQt5.QtGui import QIcon, QColor
 import PyQt5.QtMultimedia as media
 from PyQt5.QtCore import QUrl
+from PyQt5 import QtCore
 
 import json
 import os.path as osp
@@ -25,7 +26,7 @@ class JsonLoader():
         self.table = table
 
         self.major_clue = None
-        self.flashback_color = QColor(220, 255, 240)
+        self.flashback_color = QColor(150, 255, 200, 100)
         self.normal_color = QColor(255, 255, 255)
 
         if not path:
@@ -234,7 +235,8 @@ class JsonLoader():
     def hideFlashback(self):
         for rowi, talk in enumerate(self.talks):
             textItem = self.table.item(rowi, 1)
-            textItem.setBackground(self.normal_color)
+            # textItem.setBackground(self.normal_color)
+            textItem.setData(QtCore.Qt.BackgroundRole, None)
             textItem.setToolTip(None)
             # self.table.setItem(rowi, 1, textItem)
 

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -166,10 +166,11 @@ class JsonLoader():
     def showFlashback(self):
 
         if self.major_clue is None:
-            for rowi, talk in enumerate(self.talks):
-                if 'clues' in talk:
-                    textItem = self.table.item(rowi, 1)
-                    textItem.setToolTip(u"无法判断是否为闪回。\n%s\n\nNo idea about scenarioID.\nvoice ids: %s" % (str(talk['clues']), str(talk['voices'])))
+            # for rowi, talk in enumerate(self.talks):
+            #     if 'clues' in talk:
+            #         textItem = self.table.item(rowi, 1)
+            #         textItem.setToolTip(u"无法判断是否为闪回。\n%s\n\nNo idea about scenarioID.\nvoice ids: %s" % (str(talk['clues']), str(talk['voices'])))
+            self.hideFlashback()
             return
         
         # debug 
@@ -195,9 +196,11 @@ class JsonLoader():
                     #     hints = "\n" + hints
                     # textItem.setToolTip("major clue: %s\nthis sentence: %s" % (self.major_clue, str(talk['clues'])))
                 # else:
-                    textItem.setToolTip(u"闪回：%s\n\n%s\nInferred major clue: %s\nvoice ids: %s" % (hints, str(talk['clues']), self.major_clue, str(talk['voices'])))
+                    textItem.setToolTip(u"闪回：%s\n\n%s" % (hints, str(talk['voices'])))
+                    # textItem.setToolTip(u"闪回：%s\n\n%s\nInferred major clue: %s\nvoice ids: %s" % (hints, str(talk['clues']), self.major_clue, str(talk['voices'])))
                 else:
-                    textItem.setToolTip(u"%s\nInferred major clue: %s\nvoice ids: %s" % (str(talk['clues']), self.major_clue, str(talk['voices'])))
+                    textItem.setToolTip(None)
+                    # textItem.setToolTip(u"%s\nInferred major clue: %s\nvoice ids: %s" % (str(talk['clues']), self.major_clue, str(talk['voices'])))
                 self.table.setItem(rowi, 1, textItem)
     
     def hideFlashback(self):

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -169,7 +169,7 @@ class JsonLoader():
             for rowi, talk in enumerate(self.talks):
                 if 'clues' in talk:
                     textItem = self.table.item(rowi, 1)
-                    textItem.setToolTip("%s\n\nNo idea about scenarioID.\nvoice ids: %s" % (str(talk['clues']), str(talk['voices'])))
+                    textItem.setToolTip(u"无法判断是否为闪回。\n%s\n\nNo idea about scenarioID.\nvoice ids: %s" % (str(talk['clues']), str(talk['voices'])))
             return
         
         # debug 

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -28,7 +28,7 @@ class JsonLoader():
         self.flashback_color = QColor(150, 255, 200, 100)
         self.normal_color = QColor(255, 255, 255)
 
-        self.fb = flashback.FlashbackAnalyzer()
+        self.fb = flashback.FlashbackAnalyzer(listManager = listManager)
 
         if not path:
             return
@@ -173,6 +173,9 @@ class JsonLoader():
                     textItem = self.table.item(rowi, 1)
                     textItem.setToolTip("%s\n\nNo idea about scenarioID.\nvoice ids: %s" % (str(talk['clues']), str(talk['voices'])))
             return
+        
+        # debug 
+        # self.major_clue = "no"
 
         for rowi, talk in enumerate(self.talks):
 
@@ -190,11 +193,11 @@ class JsonLoader():
                     textItem.setBackground(self.flashback_color)
                     for clue in talk['clues']:
                         hints += '\n'.join(self.fb.getClueHints(clue))
-                    if hints != "":
-                        hints = "\n" + hints
+                    # if hints != "":
+                    #     hints = "\n" + hints
                     # textItem.setToolTip("major clue: %s\nthis sentence: %s" % (self.major_clue, str(talk['clues'])))
                 # else:
-                textItem.setToolTip("%s%s\n\nInferred major clue: %s\nvoice ids: %s" % (str(talk['clues']), hints, self.major_clue, str(talk['voices'])))
+                textItem.setToolTip("%s\n\n%s\nInferred major clue: %s\nvoice ids: %s" % (hints, str(talk['clues']), self.major_clue, str(talk['voices'])))
                 self.table.setItem(rowi, 1, textItem)
     
     def hideFlashback(self):

--- a/src/JsonLoader.py
+++ b/src/JsonLoader.py
@@ -10,7 +10,6 @@ import sys
 
 from Dictionary import characterDict
 from collections import Counter
-import Flashback as flashback
 
 class JsonLoader():
     if getattr(sys, 'frozen', False):
@@ -19,7 +18,7 @@ class JsonLoader():
         root, _ = osp.split(osp.abspath(sys.argv[0]))
         root = osp.join(root, "../")
 
-    def __init__(self, path="", table=None, fontSize=18, listManager=None):
+    def __init__(self, path="", table=None, fontSize=18, flashbackAnalyzer=None):
 
         self.talks = []
         self.table = table
@@ -28,7 +27,7 @@ class JsonLoader():
         self.flashback_color = QColor(150, 255, 200, 100)
         self.normal_color = QColor(255, 255, 255)
 
-        self.fb = flashback.FlashbackAnalyzer(listManager = listManager)
+        self.fb = flashbackAnalyzer
 
         if not path:
             return
@@ -41,7 +40,6 @@ class JsonLoader():
             fulldata = json.load(f)
         
         self.scenario_id = fulldata['ScenarioId']
-        self.listManager = listManager # Not used, but perhaps keep here for future use?
 
         for snippet in fulldata['Snippets']:
             # TalkData
@@ -197,7 +195,9 @@ class JsonLoader():
                     #     hints = "\n" + hints
                     # textItem.setToolTip("major clue: %s\nthis sentence: %s" % (self.major_clue, str(talk['clues'])))
                 # else:
-                textItem.setToolTip("%s\n\n%s\nInferred major clue: %s\nvoice ids: %s" % (hints, str(talk['clues']), self.major_clue, str(talk['voices'])))
+                    textItem.setToolTip(u"闪回：%s\n\n%s\nInferred major clue: %s\nvoice ids: %s" % (hints, str(talk['clues']), self.major_clue, str(talk['voices'])))
+                else:
+                    textItem.setToolTip(u"%s\nInferred major clue: %s\nvoice ids: %s" % (str(talk['clues']), self.major_clue, str(talk['voices'])))
                 self.table.setItem(rowi, 1, textItem)
     
     def hideFlashback(self):

--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -934,7 +934,7 @@ class ListManager():
     def getJsonPath(self, storyType, sort, storyIdx, chapterIdx, source):
         jsonurl = ""
         bestBaseUrl = "https://minio.dnaroma.eu/sekai-assets/"
-        # bestBaseUrl = "https://storage.sekai.best/sekai-assets/"
+        # bestBaseUrl = "https://storage.sekai.best/sekai-jp-assets/"
         aiBaseUrl = "https://assets.pjsek.ai/file/pjsekai-assets/"
         uniBaseUrl = "https://assets.unipjsk.com/"
 

--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -11,6 +11,7 @@ from Dictionary import unitDict, sekaiDict, characterDict, areaDict
 from Dictionary import greetDict_season, greetDict_celebrate, greetDict_holiday
 
 from urllib import request
+import re
 
 localProxy = request.getproxies()
 
@@ -54,6 +55,7 @@ class ListManager():
         self.specials = self.loadFile("specials.json", "Specials")
 
         self.urls = self.loadFile("../urls.json", "DB URLs", self.urls)
+        self.voiceClues = self.buildVoiceIDClues()
 
     def loadFile(self, fileName: str, content: str, default: object = None):
         if default is None:
@@ -75,6 +77,8 @@ class ListManager():
         self.updateAreatalks()
         self.updateGreets()
         self.updateSpecials()
+
+        self.inferVoiceEventID()
 
     def chooseSite(self):
         bestDBurl = self.urls['bestDBurl']
@@ -525,6 +529,107 @@ class ListManager():
         with open(specialsPath, 'w', encoding='utf-8') as f:
             json.dump(self.specials, f, indent=2, ensure_ascii=False)
         logging.info("Specials Updated")
+    
+    # Infer voice eventID (clue) from areatalks then store them into events.json
+    def inferVoiceEventID(self):
+
+        events_dict = {}
+        clues = {}
+
+        # Areatalk match string; used for extract event ids
+        pattern = r'areatalk_(ev|wl)_(.+)_\d+$'
+        self.areatalk_re = re.compile(pattern)
+
+        # Event basic info etc.
+        for ei, event in enumerate(self.events):
+
+            if 'id' not in event:
+                continue
+            
+            if 'title' not in event:
+                continue
+
+            event_desc = {
+                'array_index': ei,
+                'id': event['id'],
+                'choffset': 0, # Some event stories start from Ep. "00" instead of "01", e.g., #9
+            }
+            events_dict[event['id']] = event_desc
+
+        try:
+            # Hard-coded event properties
+            events_dict[9]['choffset'] = 1
+        except:
+            pass
+
+        # Obtain event id clue from areatalks
+        for areatalk in self.areatalks:
+            
+            if 'scenarioId' not in areatalk:
+                continue
+
+            if 'addEventId' not in areatalk:
+                continue
+
+            match = self.areatalk_re.search(areatalk['scenarioId'])
+            if match:
+                event_type = match.group(1)
+                event_clue = match.group(2)
+
+                if event_type == 'wl':
+                    event_clue = "wl_" + event_clue
+                
+                add_to_dict = False
+
+                if event_clue in clues:
+
+                    prev_id = clues[event_clue]['id']
+
+                    # Use the earliest event
+                    if prev_id >= 0 and prev_id > areatalk['addEventId']:
+                        add_to_dict = True
+
+                else:
+                    add_to_dict = True
+
+                if add_to_dict:
+                    clues[event_clue] = events_dict.get(areatalk['addEventId'], None)
+        
+        # Hard-coded patterns as the inference is not perfect
+        clues['band_01'] = events_dict.get(1, None)
+        clues['night__'] = events_dict.get(53, None)
+        clues['shuffle_03'] = events_dict.get(9, None)
+
+        # Store info into self.events
+        for clue in clues:
+
+            if clues[clue] == None:
+                continue
+
+            event_desc = clues[clue]
+            self.events[event_desc['array_index']]['inferredVoiceIDs'] = {
+                'prefix': clue,
+                'choffset': event_desc['choffset']
+            }
+        
+        # Store to file
+        eventsPath = osp.join(self.settingDir, "events.json")
+        with open(eventsPath, 'w', encoding='utf-8') as f:
+            json.dump(self.events, f, indent=2, ensure_ascii=False)
+        logging.info("Events Updated with VoiceID Information")
+
+        self.voiceClues = self.buildVoiceIDClues()
+    
+    def buildVoiceIDClues(self):
+
+        voiceClues = {}
+
+        for event in self.events:
+            if 'inferredVoiceIDs' in event:
+                ev_clue_info = event['inferredVoiceIDs']
+                voiceClues[ev_clue_info['prefix']] = event
+        
+        return voiceClues
 
     def getStoryIndexList(self, storyType: str, sort: str):
         storyIndex = []

--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -36,7 +36,7 @@ class ListManager():
         'aiDBurl' : "https://api.pjsek.ai/database/master/{}?$limit=9999&$skip=0&",
         'privateDBurl' : "https://raw.githubusercontent.com/MejiroRina/kng-sekai-master/main/master/{}.json",
 
-        'bestBaseUrl' : "https://minio.dnaroma.eu/sekai-assets/",
+        'bestBaseUrl' : "https://minio.dnaroma.eu/sekai-jp-assets/",
         'aiBaseUrl' : "https://assets.pjsek.ai/file/pjsekai-assets/",
         'uniBaseUrl' : "https://assets.unipjsk.com/",
     }

--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -31,6 +31,16 @@ class ListManager():
     DBurl = ""
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36'}
 
+    urls = {
+        'bestDBurl' : "http://sekai-world.github.io/sekai-master-db-diff/{}.json",
+        'aiDBurl' : "https://api.pjsek.ai/database/master/{}?$limit=9999&$skip=0&",
+        'privateDBurl' : "https://raw.githubusercontent.com/MejiroRina/kng-sekai-master/main/master/{}.json",
+
+        'bestBaseUrl' : "https://minio.dnaroma.eu/sekai-assets/",
+        'aiBaseUrl' : "https://assets.pjsek.ai/file/pjsekai-assets/",
+        'uniBaseUrl' : "https://assets.unipjsk.com/",
+    }
+
     def __init__(self, settingDir):
         self.settingDir = settingDir
 
@@ -43,8 +53,13 @@ class ListManager():
         self.greets = self.loadFile("greets.json", "Greets")
         self.specials = self.loadFile("specials.json", "Specials")
 
-    def loadFile(self, fileName: str, content: str):
-        data = []
+        self.urls = self.loadFile("urls.json", "DB URLs", self.urls)
+        self.storeURLs()
+
+    def loadFile(self, fileName: str, content: str, default: object = None):
+        if default is None:
+            default = []
+        data = default
         path = osp.join(self.settingDir, fileName)
         if osp.exists(path):
             with open(path, 'r', encoding='utf-8') as f:
@@ -61,11 +76,17 @@ class ListManager():
         self.updateAreatalks()
         self.updateGreets()
         self.updateSpecials()
+    
+    def storeURLs(self):
+        urlsPath = osp.join(self.settingDir, "urls.json")
+        with open(urlsPath, 'w', encoding='ascii') as f:
+            json.dump(self.urls, f, indent=2)
+        logging.info("URLs stored")
 
     def chooseSite(self):
-        bestDBurl = "http://sekai-world.github.io/sekai-master-db-diff/{}.json"
-        aiDBurl = "https://api.pjsek.ai/database/master/{}?$limit=9999&$skip=0&"
-        privateDBurl = "https://raw.githubusercontent.com/MejiroRina/kng-sekai-master/main/master/{}.json"
+        bestDBurl = self.urls['bestDBurl']
+        aiDBurl = self.urls['aiDBurl']
+        privateDBurl = self.urls['privateDBurl']
         
         sites = [privateDBurl, bestDBurl, aiDBurl]
         siteNames = ["personal", "best", "ai"]
@@ -933,10 +954,10 @@ class ListManager():
 
     def getJsonPath(self, storyType, sort, storyIdx, chapterIdx, source):
         jsonurl = ""
-        bestBaseUrl = "https://minio.dnaroma.eu/sekai-assets/"
+        bestBaseUrl = self.urls['bestBaseUrl']
         # bestBaseUrl = "https://storage.sekai.best/sekai-jp-assets/"
-        aiBaseUrl = "https://assets.pjsek.ai/file/pjsekai-assets/"
-        uniBaseUrl = "https://assets.unipjsk.com/"
+        aiBaseUrl = self.urls['aiBaseUrl']
+        uniBaseUrl = self.urls['uniBaseUrl']
 
         if storyType == u"主线剧情":
             unitIdx = storyIdx

--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -53,8 +53,7 @@ class ListManager():
         self.greets = self.loadFile("greets.json", "Greets")
         self.specials = self.loadFile("specials.json", "Specials")
 
-        self.urls = self.loadFile("urls.json", "DB URLs", self.urls)
-        self.storeURLs()
+        self.urls = self.loadFile("../urls.json", "DB URLs", self.urls)
 
     def loadFile(self, fileName: str, content: str, default: object = None):
         if default is None:
@@ -76,12 +75,6 @@ class ListManager():
         self.updateAreatalks()
         self.updateGreets()
         self.updateSpecials()
-    
-    def storeURLs(self):
-        urlsPath = osp.join(self.settingDir, "urls.json")
-        with open(urlsPath, 'w', encoding='ascii') as f:
-            json.dump(self.urls, f, indent=2)
-        logging.info("URLs stored")
 
     def chooseSite(self):
         bestDBurl = self.urls['bestDBurl']

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -22,6 +22,7 @@ from os import environ, mkdir, _exit, remove
 import platform
 import requests
 from urllib import request
+import Flashback as flashback
 
 EditorMode = [u'翻译', u'校对', u'合意', u'审核']
 
@@ -72,6 +73,10 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             logging.warning("Setting File not Exists: {}".format(settingpath))
         if 'textdir' not in self.setting:
             self.setting['textdir'] = self.datadir
+        if 'syncScroll' not in self.setting:
+            self.setting['syncScroll'] = False
+        if 'showFlashback' not in self.setting:
+            self.setting['showFlashback'] = True
         logging.info("Text Folder Path: {}".format(self.setting['textdir']))
         self.fontSize = self.setting['fontSize'] if 'fontSize' in self.setting else 18
 
@@ -85,6 +90,8 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
         if osp.exists(titleIcon):
             self.setWindowIcon(QIcon(titleIcon))
             logging.info("Icon Loaded")
+        
+        self.flashback = flashback.FlashbackAnalyzer(listManager = self.ListManager)
 
         self.setupUi(self)
         self.spinBoxFontSize.setValue(self.fontSize)
@@ -139,6 +146,9 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             lambda idx: self.moveScrollBars(idx, 'destination'))
 
         qw.QShortcut(QKeySequence(self.tr("Ctrl+S")), self, self.saveText)
+
+        self.checkBoxShowFlashback.setChecked(self.setting['showFlashback'])
+        self.checkBoxSyncScroll.setChecked(self.setting['syncScroll'])
 
         self.tempWindow = qw.QMessageBox(self)
         self.tempWindow.setStandardButtons(qw.QMessageBox.No)
@@ -202,7 +212,7 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             if not jsonpath:
                 return
             try:
-                self.srcText = JsonLoader(jsonpath, self.tableWidgetSrc, fontSize=self.fontSize, listManager=self.ListManager)
+                self.srcText = JsonLoader(jsonpath, self.tableWidgetSrc, fontSize=self.fontSize, flashbackAnalyzer=self.flashback)
                 self.toggleFlashback(self.checkBoxShowFlashback.isChecked())
                 logging.info("Json File Loaded: " + jsonpath)
             except BaseException:
@@ -926,6 +936,11 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             self.toggleSyncedMode(False)
 
     def toggleSyncedMode(self, state):
+
+        if state != self.setting['syncScroll']:
+            self.setting['syncScroll'] = state
+            save(self)
+
         if state:
             self.alignRowsHeight()
         else:
@@ -933,6 +948,11 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             self.setFontSize()
     
     def toggleFlashback(self, state):
+
+        if state != self.setting['showFlashback']:
+            self.setting['showFlashback'] = state
+            save(self)
+
         if state:
             try:
                 self.srcText.showFlashback()
@@ -945,6 +965,8 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
                         exc_type, exc_value, exc_traceback_obj, file=f)
 
                 self.checkBoxShowFlashback.setCheckState(0)
+                self.setting['showFlashback'] = False
+                save(self)
                 self.srcText.hideFlashback()
         else:
             self.srcText.hideFlashback()
@@ -1075,6 +1097,16 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
 
         logging.info("Story List Updated")
         self.setComboBoxStoryIndex()
+
+        try:
+            self.flashback = flashback.FlashbackAnalyzer(listManager = self.ListManager)
+        except BaseException:
+            logging.error("Fail to update flashback info from updated chapter infomation.")
+            exc_type, exc_value, exc_traceback_obj = sys.exc_info()
+            with open(loggingPath, 'a') as f:
+                traceback.print_exception(
+                    exc_type, exc_value, exc_traceback_obj, file=f)
+
         return True
 
     def translateMode(self):
@@ -1179,6 +1211,7 @@ class updateThread(qc.QThread):
             self.ListManager.updateSpecials()
             self.trigger.emit(self.ListManager)
             logging.info("Chapter Information Update Successed.")
+
         except BaseException:
             logging.error("Fail to Download Settingg File from best.")
             exc_type, exc_value, exc_traceback_obj = sys.exc_info()

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -937,6 +937,13 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             try:
                 self.srcText.showFlashback()
             except BaseException:
+
+                logging.error("Failed to sync scrollbars. Sync disabled.")
+                exc_type, exc_value, exc_traceback_obj = sys.exc_info()
+                with open(loggingPath, 'a') as f:
+                    traceback.print_exception(
+                        exc_type, exc_value, exc_traceback_obj, file=f)
+
                 self.checkBoxShowFlashback.setCheckState(0)
                 self.srcText.hideFlashback()
         else:

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -115,6 +115,7 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
         self.pushButtonClear.clicked.connect(self.clearText)
         # self.pushButtonDebug.clicked.connect(self.alignRowsHeight)
         self.checkBoxSyncScroll.stateChanged.connect(self.toggleSyncedMode)
+        self.checkBoxShowFlashback.stateChanged.connect(self.toggleFlashback)
 
         self.lineEditTitle.textChanged.connect(self.changeTitle)
         self.pushButtonSpeaker.clicked.connect(self.setSpeaker)
@@ -201,7 +202,8 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             if not jsonpath:
                 return
             try:
-                self.srcText = JsonLoader(jsonpath, self.tableWidgetSrc, fontSize=self.fontSize)
+                self.srcText = JsonLoader(jsonpath, self.tableWidgetSrc, fontSize=self.fontSize, listManager=self.ListManager)
+                self.toggleFlashback(self.checkBoxShowFlashback.isChecked())
                 logging.info("Json File Loaded: " + jsonpath)
             except BaseException:
                 logging.error("Fail to Load Json File: " + jsonpath)
@@ -929,6 +931,12 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
         else:
             # This resets table row heights
             self.setFontSize()
+    
+    def toggleFlashback(self, state):
+        if state:
+            self.srcText.showFlashback()
+        else:
+            self.srcText.hideFlashback()
 
     def setComboBoxStoryType(self, isInt=False):
         if 'storyType' in self.setting:

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -934,7 +934,11 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
     
     def toggleFlashback(self, state):
         if state:
-            self.srcText.showFlashback()
+            try:
+                self.srcText.showFlashback()
+            except BaseException:
+                self.checkBoxShowFlashback.setCheckState(0)
+                self.srcText.hideFlashback()
         else:
             self.srcText.hideFlashback()
 

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -952,10 +952,25 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
         if state != self.setting['showFlashback']:
             self.setting['showFlashback'] = state
             save(self)
-
+        
         if state:
             try:
                 self.srcText.showFlashback()
+
+                # Show partial check mark when failed to analyze
+                if self.srcText.major_clue is None:
+                    self.checkBoxShowFlashback.blockSignals(True)
+                    self.checkBoxShowFlashback.setEnabled(False)
+                    self.checkBoxShowFlashback.setCheckState(1)
+                    self.checkBoxShowFlashback.blockSignals(False)
+                    self.checkBoxShowFlashback.setToolTip(u"无法判断本话是否包含闪回。")
+                else:
+                    self.checkBoxShowFlashback.blockSignals(True)
+                    self.checkBoxShowFlashback.setEnabled(True)
+                    self.checkBoxShowFlashback.setCheckState(2)
+                    self.checkBoxShowFlashback.blockSignals(False)
+                    self.checkBoxShowFlashback.setToolTip(u"推测的剧情id: %s" % self.srcText.major_clue)
+
             except BaseException:
 
                 logging.error("Failed to check flashbacks. Feature disabled.")

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -938,7 +938,7 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
                 self.srcText.showFlashback()
             except BaseException:
 
-                logging.error("Failed to sync scrollbars. Sync disabled.")
+                logging.error("Failed to check flashbacks. Feature disabled.")
                 exc_type, exc_value, exc_traceback_obj = sys.exc_info()
                 with open(loggingPath, 'a') as f:
                     traceback.print_exception(

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -857,6 +857,12 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
         return self.dstText.talks[self.srcScrollLinkedDstPositionPrev]['idx'] - 1
 
     def moveScrollBars(self, idx, bar, offset = 0):
+
+        # print("%s current: %d" % (bar, idx))
+        # print("Src maximum: %d" % self.tableWidgetSrcScroll.maximum())
+        # print("Dst maximum: %d" % self.tableWidgetDstScroll.maximum())
+        # return
+        
         if not self.checkBoxSyncScroll.isChecked(): return
 
         if idx < 0: return
@@ -877,6 +883,12 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
                 if idx == 0:
                     self.srcScrollLinkedDstPositionPrev = 0
                     self.tableWidgetDstScroll.setValue(0)
+                    return
+                
+                # We get to the bottom
+                if idx == self.tableWidgetSrcScroll.maximum():
+                    self.srcScrollLinkedDstPositionPrev = self.tableWidgetDstScroll.maximum()
+                    self.tableWidgetDstScroll.setValue(self.tableWidgetDstScroll.maximum())
                     return
 
                 dirc = 0
@@ -916,11 +928,18 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
 
             elif bar == 'destination':
 
+                # We get to the bottom
+                if idx == self.tableWidgetDstScroll.maximum():
+                    self.tableWidgetSrcScroll.setValue(self.tableWidgetSrcScroll.maximum())
+                    return
+
                 # TODO: Set dst scroll to next heading line to ensure sync?
 
                 if self.checkBoxShowDiff.isChecked():
+                    # print("Attempt to set src -> %d" % (self.dstText.talks[idx]['idx'] - 1))
                     self.tableWidgetSrcScroll.setValue(self.dstText.talks[idx]['idx'] - 1)
                 else:
+                    # print("Attempt to set src -> %d" % (self.dstText.talks[self.dstText.decompressRowMap[idx]]['idx'] - 1))
                     self.tableWidgetSrcScroll.setValue(self.dstText.talks[self.dstText.decompressRowMap[idx]]['idx'] - 1)
         
         # If we had any problem syncing scroll bars, disable the sync

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -1224,6 +1224,8 @@ class updateThread(qc.QThread):
             self.ListManager.updateGreets()
             self.trigger.emit([site, "特殊剧情"])
             self.ListManager.updateSpecials()
+            self.trigger.emit([site, "推断语音ID"])
+            self.ListManager.inferVoiceEventID()
             self.trigger.emit(self.ListManager)
             logging.info("Chapter Information Update Successed.")
 

--- a/src/mainGUI.py
+++ b/src/mainGUI.py
@@ -405,7 +405,7 @@ class Ui_SekaiText(object):
         self.pushButtonSave.setText(_translate("SekaiText", u"保存"))
         self.pushButtonClear.setText(_translate("SekaiText", u"清空"))
         self.checkBoxShowFlashback.setText(_translate("SekaiText", u"标记闪回"))
-        self.checkBoxShowFlashback.setChecked(True)
+        # self.checkBoxShowFlashback.setChecked(True)
         self.checkBoxSyncScroll.setText(_translate("SekaiText", u"同步滚动"))
         self.checkBoxShowDiff.setText(_translate("SekaiText", u"显示修改前内容"))
         self.radioButtonTranslate.setChecked(True)

--- a/src/mainGUI.py
+++ b/src/mainGUI.py
@@ -123,6 +123,11 @@ class Ui_SekaiText(object):
         self.label_3.setObjectName("label_3")
         self.horizontalLayout_3.addWidget(self.label_3)
 
+        self.checkBoxShowFlashback = QtWidgets.QCheckBox(self.centralwidget)
+        self.checkBoxShowFlashback.setFixedSize(QtCore.QSize(90, 30))
+        self.checkBoxShowFlashback.setObjectName("checkBoxShowFlashback")
+        self.horizontalLayout_3.addWidget(self.checkBoxShowFlashback)
+
         self.checkBoxSyncScroll = QtWidgets.QCheckBox(self.centralwidget)
         self.checkBoxSyncScroll.setFixedSize(QtCore.QSize(90, 30))
         self.checkBoxSyncScroll.setObjectName("checkBoxSyncScroll")
@@ -399,6 +404,8 @@ class Ui_SekaiText(object):
         self.pushButtonOpen.setText(_translate("SekaiText", u"打开"))
         self.pushButtonSave.setText(_translate("SekaiText", u"保存"))
         self.pushButtonClear.setText(_translate("SekaiText", u"清空"))
+        self.checkBoxShowFlashback.setText(_translate("SekaiText", u"标记闪回"))
+        self.checkBoxShowFlashback.setChecked(True)
         self.checkBoxSyncScroll.setText(_translate("SekaiText", u"同步滚动"))
         self.checkBoxShowDiff.setText(_translate("SekaiText", u"显示修改前内容"))
         self.radioButtonTranslate.setChecked(True)


### PR DESCRIPTION
大意是根据语音id推断这句语音是否属于本话剧情，不属于本话的行会用绿色标记提示闪回。鼠标放在对应行上会有提示闪回出处

json里的`VoiceId`都是根据剧情标好号的（下称“标记” / `clue`），所以通过`VoiceId`能推断出语音属于哪期剧情。比如
```
"VoiceId": "voice_ev_wl_piapro_01_03_27_24_band",
```
就对应了 `ev_wl_piapro_01_03` 这期剧情（140-03）。后面的`27_24_band`含义一般是 `27`: 语音在本话中的id（一般是行数），`24_band`: 角色序号（LN MIKU）

但是，由于`VoiceId`里的标记和`ScenarioId`不是完全对应的（少数情况下，比如wl，是对应的），所以很难从`VoiceId`中自动推断出对应的剧情标题...
> 如`voice_card_bd_202407_15_4a_40_15`对应的`ScenarioId`为`015037_nene01`

目前只能做到提示这个提取出的语音中的剧情标记。

同时；检测`VoiceId`是否属于本话需要本话的标记名（下称“主标记名” / `major_clue`）。但因为`VoiceId`和`ScenarioId`没有对应关系，这个主标记名只能推测。
**现在是用了本话中出现频率最多的`clue`作为`major_clue`。** 不确定是否靠谱（看了一圈各期剧情感觉还可以）

做了些简单的异常处理；UI上提示的内容有点technical，不知有无建议orz
~~试过自动解析这个标记，但太复杂了放弃了……有的活动（比如53期ena2）没标序号，主线的vs部分用的是另一套命名逻辑，卡面剧情的序号也很复杂……等等~~
解析出来个大概了，见下

在 Win 11 和 MacOS 13.4 (Dark mode) 上简单试过了；开了好几期主线/活动/卡面/小对话之类的看过感觉没什么大问题w？
因为是提示闪回所以设置了启动时自动开启，出错了需要手动关闭。

截图：

(137-03)
![image](https://github.com/user-attachments/assets/8b3c9d04-9f25-439a-ab51-37825d6ed1ba)

(140-13)
![image](https://github.com/user-attachments/assets/3678fde9-2adf-4045-bcfd-d14dfbcad912)

`VoiceId`中剧情标记的一些例子（`src/Flashback.py`）：
```
      VoiceId examples:                         Matched Clue:                   Interpretation:
    - voice_op_band0_15_03                      op_band0                        Leo/Need opening
    - voice_card_18_3a_27_18                    card_18_3a                      Card: (18)Mafuyu (3)3Star (a)Part1
    - voice_ms_night13_28_18                    ms_night13                      (ms)Main Story - (night)Niigo - (13)Ep.13
    - voice_ev_wl_band_01_05_28_03              ev_wl_band_01_05                (ev)Event Story - (wl)World Link - (band)Leo/Need - (01)1st World Link?? - (05)Ep.5
    - voice_ev_street_18_06_98b_67              ev_street_18_06                 ev - (street)Vivid BAD SQUAD - (18)18th Unit Event (i.e., #135 OVER RAD SQUAD!!) - (06)Ep.6
                                                                                (98b)Variation? of voice used in line 98 (this one is at line 383) - (67)Character ID = Ken Shiraishi
    - voice_card_3rdaniv_20_2b_06_20            card_3rdaniv_20_2b              Card: (3rdaniv)Brand New Style - (20)Mizuki - (2)2Star (b)Part2
    - voice_card_ev_wl_wonder_01_15_4a_20_15    card_ev_wl_wonder_01_15_4a      Card: (ev_wl_wonder_01)WxS 1st WL - (15)Nene - (4)4Star (a)Part1
    - voice_ev_night__06_20_19                  ev_night__06                    (ev_night)Niigo event - *appearently two underscores* - (06)Ep.6 (Event ID MISSING, this is from #53)
    - voice_sc_ev_shuffle_10_01_14_03           sc_ev_shuffle_10_01             (sc)?? - (ev)Event - (shuffle)Mixed Event - (10)#10 Mixed (#30 - The BEST Summer Ever!) - (01)Ep.1
    - areatalk_ev_band_02_004_006
    - 3rd_anniversary_login_band_05_01
    - partvoice_28_021_band                     True (Ignored)                  (partvoice)General short voice for VSingers - (28)Voice No.28? - (021)MIKU - (band)Sub-unit: Leo/Need
```