### PR TITLE
活动id计算时跳过没有剧情的活动

### DIFF
--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -1103,6 +1103,16 @@ class ListManager():
                             self.chapterScenario.append("")
 
         return storyChapter
+    
+    # Replace event ID in chapter_ids with internal event ID instead (when event ID exists in chapterID).
+    def processChapterID(self, eventId, chapter_ids):
+        try:
+            ev_kdyicrID = int(chapter_ids[0])
+            ev_ep = int(chapter_ids[1])
+            if len(chapter_ids) == 2 and ev_kdyicrID > 0 and ev_ep > 0 and ev_kdyicrID == self.events[eventId-1]['kdyicr_id']:
+                return [str(eventId), *chapter_ids[1:]]
+        except ValueError:
+            return chapter_ids
 
     def getJsonPath(self, storyType, sort, storyIdx, chapterIdx, source):
         jsonurl = ""
@@ -1158,7 +1168,8 @@ class ListManager():
                 jsonurl = baseUrl + "ondemand/event_story/" \
                     "{}/scenario/{}.{}".format(event, chapter, extension)
 
-            preTitle = "-".join(chapter.split("_")[1:])
+            chapter_ids = chapter.split("_")[1:]
+            preTitle = "-".join(self.processChapterID(eventId, chapter_ids))
             jsonname = chapter + ".json"
 
         elif storyType == u"活动卡面":

--- a/src/ListManager.py
+++ b/src/ListManager.py
@@ -34,12 +34,12 @@ class ListManager():
     urls = {
         'bestDBurl' : "https://raw.githubusercontent.com/Sekai-World/sekai-master-db-diff/main/{}.json",
         'aiDBurl' : "https://api.pjsek.ai/database/master/{}?$limit=9999&$skip=0&",
-        'harukiDBurl' : "https://storage.haruki.wacca.cn/master-jp/{}.json?t=0",
+        'harukiDBurl' : "https://bot-assets.haruki.seiunx.com/master-jp/{}.json?t=0",
 
         'bestBaseUrl' : "https://minio.dnaroma.eu/sekai-jp-assets/",
         'uniBaseUrl' : "https://assets.unipjsk.com/",
         'harukiJPBaseUrl' : "https://sekai-assets-bdf29c81.seiunx.net/jp-assets/",
-        'harukiCNBaseUrl' : "https://storage.haruki.wacca.cn/assets/",
+        'harukiCNBaseUrl' : "https://bot-assets.haruki.seiunx.com/assets/",
     }
 
     def __init__(self, settingDir):
@@ -1113,6 +1113,7 @@ class ListManager():
     def getJsonPath(self, storyType, sort, storyIdx, chapterIdx, source):
         jsonurl = ""
         
+        extension = "asset"
         format = 'uni'
         if source == "sekai.best":
             format = 'best'
@@ -1120,12 +1121,13 @@ class ListManager():
         baseUrl = None
         if source == "sekai.best":
             baseUrl = self.urls['bestBaseUrl']
-        elif source == "haruki (CN)":
+        elif source == "haruki (CN) 无小对话":
             baseUrl = self.urls['harukiCNBaseUrl']
         elif source == "haruki (JP)":
             baseUrl = self.urls['harukiJPBaseUrl']
         elif source == "unipjsk.com":
             baseUrl = self.urls['uniBaseUrl']
+            extension = "json"
         else:
             logging.error("Unknown source. Using sekai.best instead.")
             baseUrl = self.urls['bestBaseUrl']
@@ -1140,10 +1142,10 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "scenario/unitstory/" \
-                    "{}_rip/{}.asset".format(unit, chapter)
+                    "{}_rip/{}.{}".format(unit, chapter, extension)
             if format == "uni":
                 jsonurl = baseUrl + "startapp/scenario/unitstory/" \
-                    "{}/{}.json".format(unit, chapter)
+                    "{}/{}.{}".format(unit, chapter, extension)
             # print(jsonurl)
 
             preTitle = chapter.replace("_", "-")
@@ -1157,10 +1159,10 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "event_story/" \
-                    "{}/scenario_rip/{}.asset".format(event, chapter)
+                    "{}/scenario_rip/{}.{}".format(event, chapter, extension)
             if format == "uni":
                 jsonurl = baseUrl + "ondemand/event_story/" \
-                    "{}/scenario/{}.json".format(event, chapter)
+                    "{}/scenario/{}.{}".format(event, chapter, extension)
 
             nameId = self.events[eventId - 1]['nameId']
 
@@ -1181,18 +1183,18 @@ class ListManager():
 
             cardNo = self.cards[cardId - 1]["cardNo"]
             chapter = str(chapterIdx % 3 + 1).zfill(2)
-            eventId = str(eventId).zfill(3)
+            eventId = str(self.events[eventId - 1]['nameId']).zfill(3)
             charname = characterDict[charId - 1]['name']
             charId = str(charId).zfill(3)
 
             if format == "best":
                 jsonurl = baseUrl + "character/member/" \
-                    "res{}_no{}_rip/{}{}_{}{}.asset".format(
-                        charId, cardNo, charId, cardNo, charname, chapter)
+                    "res{}_no{}_rip/{}{}_{}{}.{}".format(
+                        charId, cardNo, charId, cardNo, charname, chapter, extension)
             elif format == "uni":
                 jsonurl = baseUrl + "startapp/character/member/" \
-                    "res{}_no{}/{}{}_{}{}.json".format(
-                        charId, cardNo, charId, cardNo, charname, chapter) 
+                    "res{}_no{}/{}{}_{}{}.{}".format(
+                        charId, cardNo, charId, cardNo, charname, chapter, extension) 
 
             preTitle = "event{}-{}-{}".format(eventId, charname, chapter)
             jsonname = preTitle.replace("-", "_") + ".json"
@@ -1209,12 +1211,12 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "character/member/" \
-                    "res{}_no{}_rip/{}{}_{}{}.asset".format(
-                        charId, cardNo, charId, cardNo, charname, chapter)
+                    "res{}_no{}_rip/{}{}_{}{}.{}".format(
+                        charId, cardNo, charId, cardNo, charname, chapter, extension)
             elif format == "uni":
                 jsonurl = baseUrl + "startapp/character/member/" \
-                    "res{}_no{}/{}{}_{}{}.json".format(
-                        charId, cardNo, charId, cardNo, charname, chapter)
+                    "res{}_no{}/{}{}_{}{}.{}".format(
+                        charId, cardNo, charId, cardNo, charname, chapter, extension)
 
             idx = self.festivals[fesId - 1]['id']
             if 'collaboration' in self.festivals[fesId - 1]:
@@ -1252,12 +1254,12 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "character/member/" \
-                    "res{}_no{}_rip/{}{}_{}{}.asset".format(
-                        charId, rarity, charId, rarity, charname, chapter)
+                    "res{}_no{}_rip/{}{}_{}{}.{}".format(
+                        charId, rarity, charId, rarity, charname, chapter, extension)
             elif format == "uni":
                 jsonurl = baseUrl + "startapp/character/member/" \
-                    "res{}_no{}/{}{}_{}{}.json".format(
-                        charId, rarity, charId, rarity, charname, chapter)
+                    "res{}_no{}/{}{}_{}{}.{}".format(
+                        charId, rarity, charId, rarity, charname, chapter, extension)
 
             if charname == "miku" and realRarity == "02":
                 preTitle = "release-miku-{}-02-{}".format(unit, chapter)
@@ -1299,12 +1301,12 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "character/member/" \
-                    "res{}_no{}_rip/{}{}_{}{}.asset".format(
-                        charId, cardNo, charId, cardNo, charname, chapter)
+                    "res{}_no{}_rip/{}{}_{}{}.{}".format(
+                        charId, cardNo, charId, cardNo, charname, chapter, extension)
             elif format == "uni":
                 jsonurl = baseUrl + "startapp/character/member/" \
-                    "res{}_no{}/{}{}_{}{}.json".format(
-                        charId, cardNo, charId, cardNo, charname, chapter)
+                    "res{}_no{}/{}{}_{}{}.{}".format(
+                        charId, cardNo, charId, cardNo, charname, chapter, extension)
             
             preTitle = "lvelup2023-{}-{}".format(charname, chapter)
             jsonname = preTitle.replace("-", "_") + ".json"
@@ -1316,10 +1318,10 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "scenario/actionset/" \
-                    "group{}_rip/{}.asset".format(group, jsonname)
+                    "group{}_rip/{}.{}".format(group, jsonname, extension)
             elif format == "uni":
                 jsonurl = baseUrl + "startapp/scenario/actionset/" \
-                    "group{}/{}.json".format(group, jsonname)
+                    "group{}/{}.{}".format(group, jsonname, extension)
 
             preTitle = "areatalk-" + self.chapterScenario[chapterIdx][2]
             jsonname = self.chapterScenario[chapterIdx][2] + "_" + jsonname + ".json"
@@ -1350,10 +1352,10 @@ class ListManager():
 
             if format == "best":
                 jsonurl = baseUrl + "scenario/special/" \
-                    "{}_rip/{}.asset".format(story["dirName"], story["fileName"])
+                    "{}_rip/{}.{}".format(story["dirName"], story["fileName"], extension)
             elif format == "uni":
                 jsonurl = baseUrl + "startapp/scenario/special/" \
-                    "{}/{}.json".format(story["dirName"], story["fileName"])
+                    "{}/{}.{}".format(story["dirName"], story["fileName"], extension)
 
             preTitle = story["title"]
             jsonname = story["fileName"] + ".json"

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -1388,7 +1388,7 @@ class mainForm(qw.QMainWindow, Ui_SekaiText):
             if storyType != u"自定义":
                 self.comboBoxDataSource.addItem(u"sekai.best")
                 # self.comboBoxDataSource.addItem(u"pjsek.ai")
-                self.comboBoxDataSource.addItem(u"haruki (CN)")
+                self.comboBoxDataSource.addItem(u"haruki (CN) 无小对话")
                 self.comboBoxDataSource.addItem(u"haruki (JP)")
                 self.comboBoxDataSource.addItem(u"unipjsk.com")
             self.comboBoxDataSource.addItem(u"本地文件")


### PR DESCRIPTION
重写了#14 
#14 要改的地方太多了，我没有那个信心全改对……

这个pr的做法是在获取活动列表时就直接忽略了没有剧情的活动，让活动166（5v5测试）对text内部的绝大部分组件不可见；相比 #14 的弊端就是，因为166期直接在text内部不可见了，如果未来有这种（没有剧情的）活动有用的话（比如没有剧情却有小对话etc），可能还需要再改…？

以及顺便更了一下haruki源的地址

请帮我看看哪里有没有什么问题——
赶在lnwl2之前先传群了orz