### PR TITLE
refactor: Port the root directory to `platformdirs.user_data_dir` on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ urls.json
 temp/
 src/AutoSave.txt
 .DS_STORE
+.history

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyqt5~=5.15.10
 requests~=2.32.0
 pyopenssl~=25.0.0
 playsound
+platformdirs

--- a/src/Main.pyw
+++ b/src/Main.pyw
@@ -9,8 +9,9 @@ import sys
 import time
 import traceback
 from enum import Enum
-from os import mkdir, remove, listdir
+from os import mkdir, remove, listdir, makedirs
 from urllib import request
+from platformdirs import user_data_dir
 
 import PyQt5.QtCore as qc
 import PyQt5.QtWidgets as qw
@@ -1686,11 +1687,12 @@ if __name__ == '__main__':
     app = qw.QApplication(sys.argv)
 
     root, _ = osp.split(osp.abspath(sys.argv[0]))
-    if not getattr(sys, 'frozen', False):
+    
+    if platform.system() == "Darwin":
+        root = user_data_dir("Sekai Text", None)
+        makedirs(root, exist_ok=True)
+    elif not getattr(sys, 'frozen', False):
         root = osp.join(root, "../")
-
-    elif platform.system() == "Darwin":
-        root = osp.join(root, '../../../')
 
     loggingPath = osp.join(root, "setting", "log.txt")
     if not osp.exists(osp.join(root, "setting")):


### PR DESCRIPTION
## Background

Former code uses `osp.join(root, '../../../')` on macOS to determine the root dir of the application, which may be destructive in some situation. `platformdirs.user_data_dir` may be a safer choice for this usage.